### PR TITLE
Fix Sass deprecation warnings from Bootstrap 5

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
 	output: 'export',
+	sassOptions: {
+		quietDeps: true,
+	},
 };
 
 module.exports = nextConfig;

--- a/style/global.scss
+++ b/style/global.scss
@@ -1,6 +1,7 @@
 // $headings-line-height: 1.5;
-$line-height-base: 1.65;
-@import '~bootstrap/scss/bootstrap.scss';
+@use 'bootstrap/scss/bootstrap' with (
+  $line-height-base: 1.65
+);
 
 body {
   // letter-spacing: -.05em;


### PR DESCRIPTION
## Summary

- `next.config.js` に `sassOptions.quietDeps: true` を追加し、node_modules からの警告を抑制
- `global.scss` の `@import` を `@use` に移行し、Bootstrap 変数オーバーライドを `with()` 構文に変更

`npm run build` 時の Sass 警告がすべて消えます。

## Test plan

- [ ] `npm run build` で warning が出ないこと
- [ ] スタイルが変わっていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)